### PR TITLE
chore: automate android login and forgot password screen

### DIFF
--- a/tests/android/pages/android_elements.py
+++ b/tests/android/pages/android_elements.py
@@ -7,7 +7,7 @@ all_image_buttons = 'android.widget.ImageButton'
 all_textviews = 'android.widget.TextView'
 all_listviews = 'android.widget.FrameLayout'
 
-# NEW LOGISTRATION SCREEN
+# LOGISTRATION SCREEN
 landing_screen_title = 'txt_screen_title'
 landing_search_label = 'txt_search_label'
 landing_discovery_search = 'tf_discovery_search'
@@ -16,3 +16,20 @@ landing_register_button = 'btn_register'
 landing_signin_button = 'btn_sign_in'
 back_button = 'btn_back'
 signin_title = 'txt_sign_in_title'
+
+# LOGIN SCREEN
+sign_in_title = 'txt_sign_in_title'
+sign_in_description = 'txt_sign_in_description'
+sign_in_email_label = 'txt_email_label'
+sign_in_tf_email = 'tf_email'
+sign_in_password_label = 'txt_password_label'
+sign_in_tf_password = 'tf_password'
+sign_in_forgot_password = 'txt_forgot_password'
+google_auth_button = 'btn_google_auth'
+facebook_auth_button = 'btn_facebook_auth'
+microsoft_auth_button = 'btn_microsoft_auth'
+
+# FORGOT PASSWORD SCREEN
+forgot_password_title = 'txt_forgot_password_title'
+forgot_password_description = 'txt_forgot_password_description'
+forgot_password_reset_button = 'btn_reset_password'

--- a/tests/android/pages/android_landing.py
+++ b/tests/android/pages/android_landing.py
@@ -21,6 +21,11 @@ class AndroidLanding(AndroidBasePage):
             element: screen title element
         """
 
+        self.global_contents.wait_for_element_visibility(
+            self.driver,
+            android_elements.landing_screen_title
+        )
+
         return self.global_contents.wait_and_get_element(
             self.driver,
             android_elements.landing_screen_title
@@ -149,6 +154,11 @@ class AndroidLanding(AndroidBasePage):
         Returns:
             element: Back button element
         """
+
+        self.global_contents.wait_for_element_visibility(
+            self.driver,
+            android_elements.back_button
+        )
 
         return self.global_contents.wait_and_get_element(
             self.driver,

--- a/tests/android/pages/android_sign_in.py
+++ b/tests/android/pages/android_sign_in.py
@@ -1,0 +1,198 @@
+"""
+    Sign In Page Module
+"""
+
+from tests.android.pages import android_elements
+from tests.android.pages.android_base_page import AndroidBasePage
+
+
+class AndroidSignIn(AndroidBasePage):
+    """
+    Sign in screen
+    """
+
+    def get_sign_in_description(self):
+        """
+        Get sign in description
+
+        Returns:
+            element: sign in description element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.sign_in_description
+        )
+
+    def get_sign_in_email_label(self):
+        """
+        Get sign in email label
+
+        Returns:
+            element: sign in email label element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.sign_in_email_label
+        )
+
+    def get_sign_in_tf_email(self):
+        """
+        Get sign in email text field
+
+        Returns:
+            element: sign in email text field element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.sign_in_tf_email
+        )
+
+    def get_sign_in_password_label(self):
+        """
+        Get sign in password label
+
+        Returns:
+            element: sign in password label element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.sign_in_password_label
+        )
+
+    def get_sign_in_password_field(self):
+        """
+        Get sign in password field
+
+        Returns:
+            element: sign in password field element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.sign_in_tf_password
+        )
+
+    def get_sign_in_forgot_password(self):
+        """
+        Get sign in forgot password
+
+        Returns:
+            element: sign in forgot password element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.sign_in_forgot_password
+        )
+
+    def get_google_auth_button(self):
+        """
+        Get google auth button
+
+        Returns:
+            element: google auth button element
+        """
+
+        google_btn = self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.google_auth_button
+        )
+        btn_text = google_btn.find_element_by_class_name(
+            android_elements.all_textviews)
+        return btn_text
+
+    def get_facebook_auth_button(self):
+        """
+        Get facebook auth button
+
+        Returns:
+            element: facebook auth button element
+        """
+
+        facebook_btn = self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.facebook_auth_button
+        )
+        btn_text = facebook_btn.find_element_by_class_name(
+            android_elements.all_textviews)
+        return btn_text
+
+    def get_microsoft_auth_button(self):
+        """
+        Get microsoft auth button
+
+        Returns:
+            element: microsoft auth button element
+        """
+
+        microsoft_btn = self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.microsoft_auth_button
+        )
+        btn_text = microsoft_btn.find_element_by_class_name(
+            android_elements.all_textviews)
+        return btn_text
+
+    def get_signin_button(self):
+        """
+        Get signin button
+
+        Returns:
+            element: Signin button element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.landing_signin_button
+        )
+
+    def get_forgot_password_title(self):
+        """
+        Get forgot password title
+
+        Returns:
+            element: forgot password title element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.forgot_password_title
+        )
+
+    def get_forgot_password_reset_button(self):
+        """
+        Get forgot password reset button
+
+        Returns:
+            element: forgot password reset button element
+        """
+
+        reset_btn = self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.forgot_password_reset_button
+        )
+        btn_text = reset_btn.find_element_by_class_name(
+            android_elements.all_textviews)
+        return btn_text
+
+    def get_all_textviews(self):
+        """
+        Get all textviews elements
+
+        Returns:
+            List of webdriver elements: textview elements
+        """
+
+        self.global_contents.wait_for_element_visibility(
+            self.driver,
+            android_elements.all_textviews
+        )
+        all_textview_elements = self.global_contents.get_all_views_on_screen(
+            self.driver,
+            android_elements.all_textviews
+        )
+        return all_textview_elements

--- a/tests/android/tests/test_android_landing.py
+++ b/tests/android/tests/test_android_landing.py
@@ -1,5 +1,5 @@
 """
-    New Landing Test Module
+    Landing Test Module
 """
 
 from tests.android.pages.android_landing import AndroidLanding
@@ -7,31 +7,31 @@ from tests.common import values
 from tests.common.globals import Globals
 
 
-class TestAndroidNewLanding:
+class TestAndroidLanding:
     """
-    New Landing screen's Test Case
+    Landing screen's Test Case
     """
 
-    def test_start_new_landing_smoke(self, set_capabilities, setup_logging):
+    def test_start_landing_smoke(self, set_capabilities, setup_logging):
         """
         Scenarios:
-            Verify New Landing screen is loaded successfully
+            Verify Landing screen is loaded successfully
         """
 
-        setup_logging.info(f'Starting {TestAndroidNewLanding.__name__} Test Case')
-        android_new_landing = AndroidLanding(set_capabilities, setup_logging)
+        setup_logging.info(f'Starting {TestAndroidLanding.__name__} Test Case')
+        android_landing = AndroidLanding(set_capabilities, setup_logging)
 
-        assert android_new_landing.get_screen_title().text == values.LANDING_MESSAGE_IOS
-        assert android_new_landing.get_search_label().text == values.LANDING_SEARCH_TITLE
-        assert android_new_landing.get_discovery_search().text == values.LANDING_SEARCH_RESULTS_TITLE
-        android_new_landing.navigate_back_on_screen()
+        assert android_landing.get_screen_title().text == values.LANDING_MESSAGE_IOS
+        assert android_landing.get_search_label().text == values.LANDING_SEARCH_TITLE
+        assert android_landing.get_discovery_search().text == values.LANDING_SEARCH_RESULTS_TITLE
+        android_landing.navigate_back_on_screen()
 
-        assert android_new_landing.get_explore_courses().text == values.LANDING_EXLPORE_COURSES
-        assert android_new_landing.get_register_button()
-        assert android_new_landing.load_register_screen().text == values.REGISTER
-        android_new_landing.get_back_button().click()
+        assert android_landing.get_explore_courses().text == values.LANDING_EXLPORE_COURSES
+        assert android_landing.get_register_button()
+        assert android_landing.load_register_screen().text == values.REGISTER
+        android_landing.get_back_button().click()
 
-        assert android_new_landing.get_signin_button()
-        assert android_new_landing.load_signin_screen().text == values.LOGIN
-        android_new_landing.get_back_button().click()
-        assert android_new_landing.get_screen_title().text == values.LANDING_MESSAGE_IOS
+        assert android_landing.get_signin_button()
+        assert android_landing.load_signin_screen().text == values.LOGIN
+        android_landing.get_back_button().click()
+        assert android_landing.get_screen_title().text == values.LANDING_MESSAGE_IOS

--- a/tests/android/tests/test_android_sign_in.py
+++ b/tests/android/tests/test_android_sign_in.py
@@ -1,0 +1,99 @@
+"""
+    New Landing Test Module
+"""
+
+from tests.android.pages.android_landing import AndroidLanding
+from tests.android.pages.android_sign_in import AndroidSignIn
+from tests.common import values
+from tests.common.globals import Globals
+
+
+class TestAndroidSignIn:
+    """
+    Sign in screen's Test Case
+    """
+
+    def test_start_sign_in_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify sign in screen is loaded successfully
+        """
+
+        setup_logging.info(f'Starting {TestAndroidSignIn.__name__} Test Case')
+        android_landing = AndroidLanding(set_capabilities, setup_logging)
+
+        assert android_landing.get_screen_title().text == values.LANDING_MESSAGE_IOS
+        assert android_landing.get_signin_button()
+        assert android_landing.load_signin_screen().text == values.LOGIN
+
+    def test_ui_elements(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+        Verify following contents are visible on screen 
+            "Back icon", "Sign In" Title, "User name or e-mail address" label, User Name edit-field
+            Password edit-field, "Forgot your password?" option, "Sign In" button,
+            "Or sing in with" label, "Facebook" button, "Google" button,
+            "By signing in to this app, you agree to the" label,
+            "edX Terms of Service and Honor Code" option
+        Verify all screen contents have their default values
+        """
+
+        android_landing = AndroidLanding(set_capabilities, setup_logging)
+        android_sign_in = AndroidSignIn(set_capabilities, setup_logging)
+        global_contents = Globals(setup_logging)
+
+        android_landing.get_back_button().click()
+        assert android_landing.get_screen_title().text == values.LANDING_MESSAGE_IOS
+        assert android_landing.load_signin_screen().text == values.LOGIN
+        assert android_sign_in.get_sign_in_description().text == values.SIGN_IN_MESSAGE
+        assert android_sign_in.get_sign_in_email_label().text == values.REGISTER_EMAIL_TITLE
+        email_field = android_sign_in.get_sign_in_tf_email()
+        assert email_field.get_attribute('clickable') == values.TRUE_LOWERCASE
+        email_field.send_keys(global_contents.login_user_name)
+
+        assert android_sign_in.get_sign_in_password_label().text == values.PASSWORD
+        password_field = android_sign_in.get_sign_in_password_field()
+        assert password_field.get_attribute('clickable') == values.TRUE_LOWERCASE
+        password_field.send_keys(global_contents.login_password)
+
+        assert android_sign_in.get_signin_button().get_attribute('clickable') == values.TRUE_LOWERCASE
+
+        assert android_sign_in.get_google_auth_button().text == values.GOOGLE_SIGNIN
+        assert android_sign_in.get_facebook_auth_button().text == values.FACEBOOK_SIGNIN
+        assert android_sign_in.get_microsoft_auth_button().text == values.MICROSOFT_SIGNIN
+
+    def test_forgot_password_alert(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify tapping 'Forgot password?' will  load 'Reset Password' screen
+            Verify following contents are visible on 'Reset Password' alert, 
+            Alert Title, Alert Message, Email edit field, 'Reset Password' button
+            Verify that check your email screen is shown after entering email
+            Verify signin button is shown in check email screen
+            Verify signin button will load 'Sign In' screen
+        """
+
+        android_landing = AndroidLanding(set_capabilities, setup_logging)
+        android_sign_in = AndroidSignIn(set_capabilities, setup_logging)
+        global_contents = Globals(setup_logging)
+
+        forgot_password_button = android_sign_in.get_sign_in_forgot_password()
+        assert forgot_password_button.text == values.FORGOT_PASSWORD
+        forgot_password_button.click()
+        assert android_landing.get_back_button()
+        assert android_landing.get_screen_title().text == values.FORGOT_PASSWORD_TITLE
+        assert android_sign_in.get_forgot_password_title().text == values.FORGOT_PASSWORD_TITLE
+        assert android_sign_in.get_sign_in_email_label().text == values.FORGOT_EMAIL_TITLE
+        email_field = android_sign_in.get_sign_in_tf_email()
+        assert email_field.get_attribute('clickable') == values.TRUE_LOWERCASE
+        random_email = global_contents.generate_random_credentials(8)
+        email_field.send_keys(random_email + '@yop.com')
+
+        reset_button = android_sign_in.get_forgot_password_reset_button()
+        assert reset_button.text == values.RESET_PASSWORD_BUTTON
+        reset_button.click()
+
+        sign_in_button = android_sign_in.get_all_textviews()[3]
+        assert sign_in_button.text == values.LOGIN
+        sign_in_button.click()
+        assert android_sign_in.get_sign_in_description().text == values.SIGN_IN_MESSAGE


### PR DESCRIPTION
[LEARNER-9792](https://2u-internal.atlassian.net/browse/LEARNER-9792)

**Description**

Automate Login screen and Forgot password screen for Android app
Following test cases have been implemented:

- Verify sign in screen is loaded successfully
- Verify following contents are visible on screen 
            "Back icon", "Sign In" Title, "User name or e-mail address" label, User Name edit-field
            Password edit-field, "Forgot your password?" option, "Sign In" button,
            "Or sing in with" label, "Facebook" button, "Google" button,
            "By signing in to this app, you agree to the" label,
            "edX Terms of Service and Honor Code" option
- Verify all screen contents have their default values
- Verify tapping 'Forgot password?' will  load 'Reset Password' screen
-   Verify following contents are visible on 'Reset Password' alert, 
-   Alert Title, Alert Message, Email edit field, 'Reset Password' button
-   Verify that check your email screen is shown after entering email
-   Verify signin button is shown in check email screen
-   Verify signin button will load 'Sign In' screen