### PR TITLE
chore: automate ios main dashboard screen

### DIFF
--- a/tests/common/globals.py
+++ b/tests/common/globals.py
@@ -28,7 +28,7 @@ class Globals:
         self.setup_global_environment()
 
         # CAPABILITIES
-        self.ios_device_name = 'iPhone 14'
+        self.ios_device_name = 'iPhone 15'
         self.android_device_name = 'Android Phone'
         self.project_log = project_log
         self.medium_timeout = 7
@@ -122,7 +122,7 @@ class Globals:
                     expected_conditions.presence_of_all_elements_located((By.CLASS_NAME, target_elements)))
             elif self.target_environment == values.IOS:
                 all_views = WebDriverWait(driver, self.maximum_timeout).until(
-                    expected_conditions.presence_of_all_elements_located((MobileBy.ACCESSIBILITY_ID, target_elements)))
+                    expected_conditions.presence_of_all_elements_located((MobileBy.CLASS_NAME, target_elements)))
             self.index = 0
             if all_views:
                 no_of_all_views = len(all_views)

--- a/tests/common/values.py
+++ b/tests/common/values.py
@@ -14,6 +14,7 @@ ERROR_UTF_ELEMENT = 'Unable to find specific element - '
 TRUE_LOWERCASE = 'true'
 FALSE_LOWERCASE = 'false'
 ANDROID_APP_VERSION = 'Version: 6.0.0'
+IOS_SELECTED_TAB_VALUE = '1'
 
 # LANDING SCREEN
 LANDING_MESSAGE = 'Welcome to edX'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ from tests.common import values
 from tests.common.globals import Globals
 from tests.android.pages.android_landing import AndroidLanding
 from tests.android.pages.android_sign_in import AndroidSignIn
+from tests.ios.pages.ios_landing import IosLanding
+from tests.ios.pages.ios_login import IosLogin
 
 
 @pytest.fixture(scope="module")
@@ -121,6 +123,8 @@ def login(set_capabilities, setup_logging):
     is_first_time = True
     android_landing = AndroidLanding(set_capabilities, setup_logging)
     android_sign_in = AndroidSignIn(set_capabilities, setup_logging)
+    ios_landing = IosLanding(set_capabilities, setup_logging)
+    ios_login = IosLogin(set_capabilities, setup_logging)
 
     if global_contents.target_environment == values.ANDROID:
         assert android_landing.get_screen_title().text == values.LANDING_MESSAGE_IOS
@@ -143,6 +147,29 @@ def login(set_capabilities, setup_logging):
     elif global_contents.target_environment == values.IOS:
         log.info('Login screen successfully loaded')
 
+        if ios_landing.get_allow_notifications_button():
+            ios_landing.get_allow_notifications_button().click()
+
+        sign_in_button = ios_landing.get_sign_in_button()
+        assert ios_landing.get_sign_in_button().text == values.LOGIN
+        sign_in_button.click()
+        sign_in_title = ios_login.get_sign_in_title()
+        assert sign_in_title.text == values.LOGIN
+
+        email_field = ios_login.get_signin_username_textfield()
+        assert email_field.text == values.EMAIL_OR_USERNAME_IOS
+        email_field.send_keys(global_contents.login_user_name)
+
+        password_title = ios_login.get_signin_password_text()
+        assert password_title.text == values.PASSWORD
+        password_title.click()
+        password_field = ios_login.get_signin_password_textfield()
+        assert password_field.get_attribute('value') == values.PASSWORD
+        password_field.send_keys(global_contents.login_password)
+        password_title.click()
+        sign_in_button = ios_login.get_signin_button()
+        assert sign_in_button.text == values.LOGIN
+        sign_in_button.click()
         is_first_time = False
         log.info('{} is successfully logged in'.format(global_contents.login_user_name))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,6 @@ def login(set_capabilities, setup_logging):
 
     log = setup_logging
     global_contents = Globals(log)
-    is_first_time = True
     android_landing = AndroidLanding(set_capabilities, setup_logging)
     android_sign_in = AndroidSignIn(set_capabilities, setup_logging)
     ios_landing = IosLanding(set_capabilities, setup_logging)
@@ -170,11 +169,9 @@ def login(set_capabilities, setup_logging):
         sign_in_button = ios_login.get_signin_button()
         assert sign_in_button.text == values.LOGIN
         sign_in_button.click()
-        is_first_time = False
-        log.info('{} is successfully logged in'.format(global_contents.login_user_name))
+        setup_logging.info(f'{global_contents.login_user_name} is successfully logged in')
 
-    return is_first_time
-
+    return setup_logging
 
 def create_result_directory(target_directory):
     """

--- a/tests/ios/pages/ios_elements.py
+++ b/tests/ios/pages/ios_elements.py
@@ -21,6 +21,7 @@ landing_discover_title = 'Search results'
 logistration_register_button = 'logistration_register_button'
 logistration_signin_button = 'logistration_signin_button'
 register_screen_title = 'register_text'
+notification_allow_button = 'Allow'
 
 # SIGN IN SCREEN
 signin_text = 'signin_text'
@@ -84,3 +85,9 @@ whats_new_msg_title = 'title_text'
 whats_new_description = 'description_text'
 whats_new_btn_next = 'next_button'
 whats_new_btn_prev = 'previous_button'
+
+# MAIN DASHBOARD SCREEN
+main_dashboard_discover_tab = 'Discover'
+main_dashboard_programs_tab = 'Programs'
+main_dashboard_profile_tab = 'Profile'
+main_dashboard_tab = 'Dashboard'

--- a/tests/ios/pages/ios_landing.py
+++ b/tests/ios/pages/ios_landing.py
@@ -148,3 +148,15 @@ class IosLanding(IosBasePage):
             ios_elements.logistration_signin_button
         )
         return sign_in_button
+
+    def get_allow_notifications_button(self):
+        """
+        Get Allow button
+
+        Returns:
+            webdriver element: Allow Element
+        """
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            ios_elements.notification_allow_button)

--- a/tests/ios/pages/ios_main_dashboard.py
+++ b/tests/ios/pages/ios_main_dashboard.py
@@ -1,0 +1,79 @@
+"""
+    Main Dashboard Page Module
+"""
+from appium.webdriver.common.mobileby import MobileBy
+from tests.ios.pages import ios_elements
+from tests.ios.pages.ios_base_page import IosBasePage
+
+
+class IosMainDashboard(IosBasePage):
+    """
+    Main Dashboard screen
+    """
+
+    def get_close_button(self):
+        """
+        Get close button
+
+        Returns:
+            webdriver element: close Element
+        """
+
+        self.global_contents.wait_for_element_visibility(
+            self.driver,
+            ios_elements.whats_new_btn_next
+        )
+
+        return self.driver.find_element(MobileBy.NAME, 'close_button')
+
+    def get_main_dashboard_discover_tab(self):
+        """
+        Get discover tab
+
+        Returns:
+            webdriver element: Discover tab element
+        """
+
+        discover_tab = self.global_contents.get_all_views_on_screen(
+            self.driver,
+            ios_elements.all_buttons)[0]
+        return discover_tab
+
+    def get_main_dashboard_programs_tab(self):
+        """
+        Get programs tab
+
+        Returns:
+            webdriver element: Programs tab element
+        """
+
+        programs_tab = self.global_contents.get_all_views_on_screen(
+            self.driver,
+            ios_elements.all_buttons)[2]
+        return programs_tab
+
+    def get_main_dashboard_tab(self):
+        """
+        Get dashbaord tab
+
+        Returns:
+            webdriver element: Dashboard tab element
+        """
+
+        dashboard = self.global_contents.get_all_views_on_screen(
+            self.driver,
+            ios_elements.all_buttons)[1]
+        return dashboard
+
+    def get_main_dashboard_profile_tab(self):
+        """
+        Get profile tab
+
+        Returns:
+            webdriver element: profile tab element
+        """
+
+        profile_tab = self.global_contents.get_all_views_on_screen(
+            self.driver,
+            ios_elements.all_buttons)[3]
+        return profile_tab

--- a/tests/ios/tests/test_ios_main_dashboard.py
+++ b/tests/ios/tests/test_ios_main_dashboard.py
@@ -1,0 +1,64 @@
+"""
+    Main Dashboard Test Module
+"""
+
+from tests.ios.pages.ios_landing import IosLanding
+from tests.ios.pages.ios_login import IosLogin
+from tests.ios.pages.ios_main_dashboard import IosMainDashboard
+from tests.ios.pages.ios_whats_new import IosWhatsNew
+from tests.common import values
+from tests.common.globals import Globals
+
+
+class TestIosMainDashboard:
+    """
+    Main Dashboard screen's Test Case
+    """
+
+    def test_start_main_dashboard_smoke(self, login, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify Main Dashboard is loaded successfully
+        """
+
+        setup_logging.info(f'Starting {TestIosMainDashboard.__name__} Test Case')
+        global_contents = Globals(setup_logging)
+        whats_new_page = IosWhatsNew(set_capabilities, setup_logging)
+
+        if login and global_contents.whats_new_enable:
+            assert whats_new_page.navigate_features().text == 'Done'
+            whats_new_page.get_next_btn().click()
+            setup_logging.info('Whats New screen is successfully loaded')
+
+    def test_ui_elements_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify following contents are visible on screen, 
+                Screen Title, Disover Tab
+                Profile Tab, Programs Tab, Profiel tab
+            Verify that Discover tab will be selected by default
+            Verify that clicking each tab will load its screen
+        """
+
+        main_dashboard = IosMainDashboard(set_capabilities, setup_logging)
+        discover_tab = main_dashboard.get_main_dashboard_discover_tab()
+        assert discover_tab.text == values.DISCOVER_SCREEN_HEADING
+        discover_tab.click()
+        assert discover_tab.get_attribute('value') == values.IOS_SELECTED_TAB_VALUE
+
+        dashboard_tab = main_dashboard.get_main_dashboard_tab()
+        assert dashboard_tab.get_attribute('name') == values.MAIN_DASHBOARD_DASHBOARD_TAB
+        dashboard_tab.click()
+        assert dashboard_tab.get_attribute('value') == values.IOS_SELECTED_TAB_VALUE
+
+        programs_tab = main_dashboard.get_main_dashboard_programs_tab()
+        assert programs_tab.text == values.MAIN_DASHBOARD_PROGRAMS_TAB
+        programs_tab.click()
+        assert programs_tab.get_attribute('value') == values.IOS_SELECTED_TAB_VALUE
+
+        profile_tab = main_dashboard.get_main_dashboard_profile_tab()
+        assert profile_tab.text == values.MAIN_DASHBOARD_PROFILE_TAB
+        profile_tab.click()
+        assert profile_tab.get_attribute('value') == values.IOS_SELECTED_TAB_VALUE
+
+        setup_logging.info('All tabs are successfully loaded')


### PR DESCRIPTION
[LEARNER-9847](https://2u-internal.atlassian.net/browse/LEARNER-9847)

**Description**

Following scenarios will be implemented:
Create test and page files for ios main dashboard screen
Update value and elements files for ios main dashboard
Create login fixture and add it in main dashboard test file
Verify Main Dashboard is loaded successfully
Verify following contents are visible on screen, 
                Screen Title, Disover Tab
                Profile Tab, Programs Tab, Profiel tab
            Verify that Discover tab will be selected by default
            Verify that clicking each tab will load its screen