### PR TITLE
chore: automate course home tab screen for ios

### DIFF
--- a/tests/common/values.py
+++ b/tests/common/values.py
@@ -42,6 +42,9 @@ APPLE_SIGNIN = 'Continue with: Apple'
 BACK_BUTTON = 'Start'
 BACK_BUTTON_SMALL = 'back'
 SOCIAL_AUTH_TITLE = 'Or sign in with:'
+GOOGLE_SIGNIN_ANDROID = 'Sign in with Google'
+FACEBOOK_SIGNIN_ANDRIOD = 'Sign in with Facebook'
+MICROSOFT_SIGNIN_ANDROID = 'Sign in with Microsoft'
 
 # REGISTER SCREEN
 REGISTER = 'Register'
@@ -209,3 +212,16 @@ DISCOVERY_MATH_PAGINATION_RESULTS = '204 results'
 DISCOVERY_PAGINATION_TEXT = 'pagination'
 DISCOVERY_PAGINATION_TEXT_IOS = 'pagination, navigation'
 DISCOVERY_DEMOX_COURSE = 'DemoX edX Course'
+
+# COURSE HOME TAB SCREEN
+COURSE_MISSED_DEADLINES_LABEL = "Missed some deadlines?"
+COURSE_DEADLINE_DESCRIPTION_LABEL = ("Don't worry - shift our suggested schedule to complete past "
+                                    "due assignments without losing any progress.")
+COURSE_SHIFT_DUE_DATES = "Shift due dates"
+COURSE_RESUME_WITH_LABEL = "Resume with:"
+COURSE_RESUME_BUTTON = "Resume"
+COURSE_SECTION_LABEL = "Introduction"
+COURSE_SUBSECTION_LABEL = "Welcome to an edX Course!"
+COURSE_SECTION_1_LABEL = "Module 1: Experiencing Course Content"
+COURSE_SUBSECTION_1_LABEL = "Lesson 1: edX Content Basics"
+COURSE_COMPONENT_LABEL = "Homework 1: Your First Grade"

--- a/tests/ios/pages/ios_elements.py
+++ b/tests/ios/pages/ios_elements.py
@@ -148,6 +148,7 @@ course_dashboard_videos_tab = 'Videos'
 course_dashboard_discussions_tab = 'Discussions'
 course_dashboard_dates_tab = 'Dates'
 course_dashboard_more_tab = 'More'
+course_dashboard_back_button = "back_button"
 
 # DISCOVERY SCREEN
 discovery_back_button = 'Start'

--- a/tests/ios/tests/test_ios_course_home_tab.py
+++ b/tests/ios/tests/test_ios_course_home_tab.py
@@ -66,7 +66,8 @@ class TestIosCourseHomeTab:
         global_contents = Globals(setup_logging)
         ios_landing = IosLanding(set_capabilities, setup_logging)
 
-        second_course_name = global_contents.get_element_by_name_ios(set_capabilities, values.MY_COURSES_SECOND_COURSE_NAME)
+        second_course_name = global_contents.get_element_by_name_ios(
+            set_capabilities, values.MY_COURSES_SECOND_COURSE_NAME)
 
         second_course_name.click()
         if ios_landing.get_allow_notifications_button():
@@ -75,16 +76,20 @@ class TestIosCourseHomeTab:
         course_tab = course_dashboard_page.get_course_dashboard_course_tab()
         assert course_tab.text == values.COURSE_DASHBOARD_HOME_TAB
 
-        deadline_title = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_MISSED_DEADLINES_LABEL)
+        deadline_title = global_contents.get_element_by_label_ios(
+            set_capabilities, values.COURSE_MISSED_DEADLINES_LABEL)
         assert deadline_title.text == values.COURSE_MISSED_DEADLINES_LABEL
 
-        deadline_description = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_DEADLINE_DESCRIPTION_LABEL)
+        deadline_description = global_contents.get_element_by_label_ios(
+            set_capabilities, values.COURSE_DEADLINE_DESCRIPTION_LABEL)
         assert deadline_description.text == values.COURSE_DEADLINE_DESCRIPTION_LABEL
 
-        shift_due_dates_button = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_SHIFT_DUE_DATES)
+        shift_due_dates_button = global_contents.get_element_by_label_ios(
+            set_capabilities, values.COURSE_SHIFT_DUE_DATES)
         assert shift_due_dates_button.text == values.COURSE_SHIFT_DUE_DATES
 
-        continue_with_lable = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_RESUME_WITH_LABEL)
+        continue_with_lable = global_contents.get_element_by_label_ios(
+            set_capabilities, values.COURSE_RESUME_WITH_LABEL)
         assert continue_with_lable.text == values.COURSE_RESUME_WITH_LABEL
 
         resume_button = global_contents.get_elements_by_name_ios(set_capabilities, values.COURSE_RESUME_BUTTON)[1]
@@ -99,7 +104,8 @@ class TestIosCourseHomeTab:
         assert subsection_elem.text == values.COURSE_SUBSECTION_LABEL
         subsection_elem.click()
 
-        component_header_title = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_SUBSECTION_LABEL)
+        component_header_title = global_contents.get_element_by_label_ios(
+            set_capabilities, values.COURSE_SUBSECTION_LABEL)
         assert component_header_title.text == values.COURSE_SUBSECTION_LABEL
 
         back_btn = global_contents.wait_and_get_element(set_capabilities, ios_elements.course_dashboard_back_button)

--- a/tests/ios/tests/test_ios_course_home_tab.py
+++ b/tests/ios/tests/test_ios_course_home_tab.py
@@ -1,0 +1,151 @@
+"""
+    Course Home Tab Screen Test Module
+"""
+
+from tests.ios.pages.ios_course_dashboard import IosCourseDashboard
+from tests.ios.pages.ios_landing import IosLanding
+from tests.ios.pages.ios_main_dashboard import IosMainDashboard
+from tests.ios.pages.ios_profile import IosProfile
+from tests.ios.pages.ios_whats_new import IosWhatsNew
+from tests.ios.pages import ios_elements
+from tests.common import values
+from tests.common.globals import Globals
+
+
+class TestIosCourseHomeTab:
+    """
+    Course Home Tab screen's Test Case
+    """
+
+    def test_start_profile_screen_smoke(self, login, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify Profile is loaded successfully
+        """
+
+        setup_logging.info(f'Starting {TestIosCourseHomeTab.__name__} Test Case')
+        global_contents = Globals(setup_logging)
+        whats_new_page = IosWhatsNew(set_capabilities, setup_logging)
+        main_dashboard = IosMainDashboard(set_capabilities, setup_logging)
+
+        if login and global_contents.whats_new_enable:
+            assert whats_new_page.navigate_features().text == 'Done'
+            whats_new_page.get_next_btn().click()
+            setup_logging.info('Whats New screen is successfully loaded')
+
+        learn_tab = main_dashboard.get_main_dashboard_learn_tab()
+        learn_tab.click()
+        assert learn_tab.get_attribute('value') == values.IOS_SELECTED_TAB_VALUE
+
+    def test_validate_ui_elements(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify that clicking course from Main dashboard load course dashboard,
+            Verify that Course Dashboard tab will show following contents,
+            Header contents,
+                Back icon,
+                Specific "<course name>" as Title, Share icon, Course,
+            Verify course deadline title and description
+            Verify shift due dates button
+            Verify continue with label
+            Verify resume button
+            Verify introduction section
+            Verify subsection element
+            Verify clicking subsection element will load component screen
+            Verify component header title
+            Verify back button
+            Verify section element
+            Verify second subsection element
+            Verify clicking second subsection element will load component screen
+            Verify homework element
+            Verify second component header
+            Verify back button
+        """
+
+        course_dashboard_page = IosCourseDashboard(set_capabilities, setup_logging)
+        global_contents = Globals(setup_logging)
+        ios_landing = IosLanding(set_capabilities, setup_logging)
+
+        second_course_name = global_contents.get_element_by_name_ios(set_capabilities, values.MY_COURSES_SECOND_COURSE_NAME)
+
+        second_course_name.click()
+        if ios_landing.get_allow_notifications_button():
+            ios_landing.get_allow_notifications_button().click()
+
+        course_tab = course_dashboard_page.get_course_dashboard_course_tab()
+        assert course_tab.text == values.COURSE_DASHBOARD_HOME_TAB
+
+        deadline_title = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_MISSED_DEADLINES_LABEL)
+        assert deadline_title.text == values.COURSE_MISSED_DEADLINES_LABEL
+
+        deadline_description = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_DEADLINE_DESCRIPTION_LABEL)
+        assert deadline_description.text == values.COURSE_DEADLINE_DESCRIPTION_LABEL
+
+        shift_due_dates_button = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_SHIFT_DUE_DATES)
+        assert shift_due_dates_button.text == values.COURSE_SHIFT_DUE_DATES
+
+        continue_with_lable = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_RESUME_WITH_LABEL)
+        assert continue_with_lable.text == values.COURSE_RESUME_WITH_LABEL
+
+        resume_button = global_contents.get_elements_by_name_ios(set_capabilities, values.COURSE_RESUME_BUTTON)[1]
+        assert resume_button.text == values.COURSE_RESUME_BUTTON
+
+        global_contents.scroll_from_element(set_capabilities, resume_button)
+        introduction_section = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_SECTION_LABEL)
+        assert introduction_section.text == values.COURSE_SECTION_LABEL
+        introduction_section.click()
+
+        subsection_elem = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_SUBSECTION_LABEL)
+        assert subsection_elem.text == values.COURSE_SUBSECTION_LABEL
+        subsection_elem.click()
+
+        component_header_title = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_SUBSECTION_LABEL)
+        assert component_header_title.text == values.COURSE_SUBSECTION_LABEL
+
+        back_btn = global_contents.wait_and_get_element(set_capabilities, ios_elements.course_dashboard_back_button)
+        assert back_btn.text == values.LANDING_BACK_BUTTON
+        back_btn.click()
+
+        section1_elem = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_SECTION_1_LABEL)
+        assert section1_elem.text == values.COURSE_SECTION_1_LABEL
+        section1_elem.click()
+
+        subsection1_elem = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_SUBSECTION_1_LABEL)
+        assert subsection1_elem.text == values.COURSE_SUBSECTION_1_LABEL
+
+        homework_elem = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_COMPONENT_LABEL)
+        assert homework_elem.text == values.COURSE_COMPONENT_LABEL
+        homework_elem.click()
+
+        component_header = global_contents.get_element_by_label_ios(set_capabilities, values.COURSE_COMPONENT_LABEL)
+        assert component_header.text == values.COURSE_COMPONENT_LABEL
+
+        back_btn = global_contents.wait_and_get_element(set_capabilities, ios_elements.course_dashboard_back_button)
+        assert back_btn.text == values.LANDING_BACK_BUTTON
+        back_btn.click()
+        global_contents.wait_and_get_element(set_capabilities, ios_elements.course_dashboard_back_button).click()
+
+    def test_sign_out_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify that clicking logout button should load logout dialog
+            Verify that tapping close button should leave logout dialog
+            Verify that tapping logout button should logout from main dashboard screen
+        """
+
+        ios_profile = IosProfile(set_capabilities, setup_logging)
+        ios_landing = IosLanding(set_capabilities, setup_logging)
+        main_dashboard = IosMainDashboard(set_capabilities, setup_logging)
+
+        profile_tab = main_dashboard.get_main_dashboard_profile_tab()
+        assert profile_tab.text == values.MAIN_DASHBOARD_PROFILE_TAB
+        profile_tab.click()
+        assert ios_profile.get_profile_settings_button().text == values.PROFILE_SETTINGS_TEXT
+        ios_profile.get_profile_settings_button().click()
+        assert ios_profile.get_profile_logout_button().text.lower() == values.PROFILE_LOGOUT_BUTTON
+        ios_profile.get_profile_logout_button().click()
+        assert ios_profile.get_logout_close_button().text == 'Close'
+        assert ios_profile.get_logout_dialog_title().text == values.LOGOUT_DIALOG_TITLE
+        assert ios_profile.get_logout_button().text.lower() == values.PROFILE_LOGOUT_BUTTON
+        ios_profile.get_logout_button().click()
+        assert ios_landing.get_welcome_message().text == values.LANDING_MESSAGE_IOS

--- a/tests/ios/tests/test_ios_my_courses_list.py
+++ b/tests/ios/tests/test_ios_my_courses_list.py
@@ -63,7 +63,7 @@ class TestIosMyCoursesList:
         resume_course = buttons[6]
         assert 'Resume' in resume_course.text
         second_course = buttons[8]
-        assert second_course.text == values.MY_COURSES_SECOND_COURSE_NAME
+        assert second_course.text == values.MAIN_DASHBOARD_COURSE_NAME
         third_course = buttons[9]
         assert third_course.text == 'How to Learn Online'
         assert values.MAIN_DASHBOARD_COURSE_DESCRIPTION in my_courses_list.get_my_courses_welcomeback_text().text


### PR DESCRIPTION
[LEARNER-10382](https://2u-internal.atlassian.net/browse/LEARNER-10382)

**Description**

Following test cases are automated for the Course home tab screen:

Verify Main Dashboard screen is loaded successfully
Verify that clicking course from Main dashboard load course dashboard,
Verify that Course Dashboard tab will show following contents,
Header contents,
Back icon,
Specific <Title> as Title, Share icon, Course,
Verify course deadline title and description
Verify shift due dates button
Verify continue with label
Verify resume button
Verify introduction section
Verify subsection element
Verify clicking subsection element will load component screen
Verify component header title
Verify back button
Verify section element
Verify second subsection element
Verify clicking second subsection element will load component screen
Verify homework element
Verify second component header
Verify back button
Verify that clicking logout button should load logout dialog
Verify that tapping close button should leave logout dialog
Verify that tapping logout button should logout from main dashboard screen
Verify that clicking logout button should load logout dialog
Verify that tapping close button should leave logout dialog
Verify that tapping logout button should logout from main dashboard screen