### PR TITLE
refactor: improved conftest and readme for browserstack integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,22 +83,28 @@ Follow the link to [improve the quality of code](./docs/linting.md)
 ### Integration Steps
 - Complete the following steps to integrate your Python test suite using BrowserStack SDK.
 
-### Set BrowserStack Credentials
+### Set BrowserStack Credentials and other env variables
 - `export BROWSERSTACK_USERNAME="************"`
 - `export BROWSERSTACK_ACCESS_KEY="************"`
+- `export PLATFORM_NAME=Android/iOS`
 
 Saving your BrowserStack credentials as environment variables makes it simple to run your test suite from your local or CI environment.
+PLATFORM_NAME is a custom variable used to make test run unique and identifiable.
 
 ### Install BrowserStack Python SDK
 - `python3 -m pip install browserstack-sdk`
-- `browserstack-sdk setup --username "**************" --key "**************"`
 
 Execute the following commands to install BrowserStack Python SDK for plug-and-play integration of your test suite with BrowserStack.
 
 ### Setup
-- Update `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` in `browserstack.yml` file
+- Add following enviornment variables
+  - `BROWSERSTACK_USERNAME`
+  - `BROWSERSTACK_ACCESS_KEY`
+  - `PLATFORM_NAME`
 
-- Update device name and version for android and ios in `browserstack.yml` file
+- vales for `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` can be foound in your browserstack profile.
+
+- Update device name and version for android and ios in `browserstack.yml` file. A complete list of available devices can be found on https://www.browserstack.com/list-of-browsers-and-platforms/automate
   - platformName: `Android`/`iOS`
   - deviceName: `Google Pixel 7 pro`/`iPhone 14 pro max`
   - platformVersion: `13.0`/`16`
@@ -117,8 +123,19 @@ Execute the following commands to install BrowserStack Python SDK for plug-and-p
 - To run parallel execution on multiple devices, more platform details can be given with their device name and platform version
 ### Run
 
-- `PLATFORM_NAME=Android browserstack-sdk pytest -v tests/android/tests/` to run all android
+- `browserstack-sdk pytest tests/android/tests/ --env browserstack` to run all android
 test screens
 
-- `PLATFORM_NAME=iOS browserstack-sdk pytest -v tests/ios/tests/` to run all ios
+- `browserstack-sdk pytest tests/ios/tests/ --env browserstack` to run all ios
 test screens
+
+- `browserstack-sdk pytest -m SMOKE --env browserstack` to run all tests with smoke marker
+
+You can also use any other way of selecting tests which are available under pytest
+
+### Allure Report
+By default each pytest command execution will clean out the allure-results folder as specified in the `pytest.ini` file.
+In order to create a report on your local machine use the command
+- `allure serve` this will generate allure report and serve it at local endpoint provided in the terminal where the command is run
+To create a single file allure report for sharing purpose use the following command
+- `allure generate allure-results --clean --single-file -o allure-report ` This will generate a single html file under allure-report folder as specified in the command with `-o` option.

--- a/browserstack.yml
+++ b/browserstack.yml
@@ -4,8 +4,8 @@
 # =============================
 # Add your BrowserStack userName and accessKey here or set BROWSERSTACK_USERNAME and
 # BROWSERSTACK_ACCESS_KEY as env variables
-userName: xxxxxxxxxxxxx
-accessKey: xxxxxxxxxxxx
+userName: ${BROWSERSTACK_USERNAME}
+accessKey: ${BROWSERSTACK_ACCESS_KEY}
 # ======================
 # BrowserStack Reporting
 # ======================
@@ -26,15 +26,18 @@ buildIdentifier: '${BUILD_NUMBER}'
 # Platforms object contains all the browser / device combinations you want to test on.
 # Entire list available here -> (https://www.browserstack.com/list-of-browsers-and-platforms/automate)
 platforms:
-  - platformName: Android
-    deviceName: Google Pixel 7 pro
-    platformVersion: 13.0
+  - platformName: android
+    platformVersion: 1[45]
+    deviceName: Samsung .*
+#  - platformName: android
+#    platformVersion: 1[45]
+#    deviceName: Google Pixel 8 Pro
   # - platformName: ios
   #   deviceName: iPhone 14 Pro Max
   #   platformVersion: 16
 
-# Update the local path to the app file below (Android: .apk, iOS: .ipa) 
-app: '/path-to-app/sample-app.apk'
+# Update the local path to the app file below (Android: .apk, iOS: .ipa)
+app: 'path/to/app'
 
 # ===================
 # Debugging features
@@ -46,3 +49,4 @@ consoleLogs: errors # <string> Remote browser's console debug levels to be print
 testObservability: true
 appProfiling: true
 appiumLogs: true
+#parallelsPerPlatform: 2

--- a/tests/android/tests/test_android_smoke_account_registration_with_email_and_password.py
+++ b/tests/android/tests/test_android_smoke_account_registration_with_email_and_password.py
@@ -20,6 +20,7 @@ from tests.common.globals import Globals
 @allure.story("Registration with email and password")
 @allure.suite("SMOKE")
 @pytest.mark.ANDROID
+@pytest.mark.ANDROID_ACCOUNTS
 @pytest.mark.ANDROID_SMOKE
 class TestAccountRegistrationWithEmailAndPassword:
     """Test Account Registration with Email and Password"""

--- a/tests/android/tests/test_android_smoke_account_signin_with_email_and_password.py
+++ b/tests/android/tests/test_android_smoke_account_signin_with_email_and_password.py
@@ -18,6 +18,7 @@ from tests.common.globals import Globals
 @allure.story("Sign In with email and password")
 @allure.suite("SMOKE")
 @pytest.mark.ANDROID
+@pytest.mark.ANDROID_ACCOUNTS
 @pytest.mark.ANDROID_SMOKE
 class TestAccountSignInWithEmailAndPassword:
     """Test Account Sign In with Email and Password"""

--- a/tests/android/tests/test_android_smoke_forgot_password.py
+++ b/tests/android/tests/test_android_smoke_forgot_password.py
@@ -16,6 +16,7 @@ from tests.common import utils, values
 @allure.story("Forgot password")
 @allure.suite("SMOKE")
 @pytest.mark.ANDROID
+@pytest.mark.ANDROID_ACCOUNTS
 @pytest.mark.ANDROID_SMOKE
 class TestAndroidForgotPassword:
     """

--- a/tests/ios/tests/test_ios_regression_account_signup_with_email_and_password.py
+++ b/tests/ios/tests/test_ios_regression_account_signup_with_email_and_password.py
@@ -19,7 +19,7 @@ from tests.ios.pages.ios_whats_new import IosWhatsNew
 @allure.epic("Accounts")
 @allure.feature("Account Registration")
 @allure.story("Sign Up with Email and Password")
-@pytest.mark.IOS_Regression
+@pytest.mark.IOS_REGRESSION
 class TestAccountRegistrationSignupWithEmailAndPassword:
     """Regression test for account registration using email and password on iOS."""
 


### PR DESCRIPTION
**Description**
To run tests on browserstack simply use the command:
```browserstack-sdk pytest tests/ios/tests/ --env browserstack```
To run on local:
```pytest tests/ios/tests/ --env local```
Note: you can skip the --env local as it is set by default.
* make changes to browserstack.yml as instructed in README.md
* ticket: [learner-10640](https://2u-internal.atlassian.net/browse/LEARNER-10640)